### PR TITLE
Add exception handling for snapshot/iModel open failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ See <http://imodeljs.org> for comprehensive documentation on the iModel.js API a
     npm install
     ```
 
-2. Start the app:
+2. Build the app:
+
+    ```sh
+    npm run build
+    ```
+
+3. Start the app:
 
     ```sh
     npm start

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "npm run pseudolocalize && npm run build:backend && cross-env USE_FAST_SASS=true npm run build:frontend && npm run copy",
+    "build": "npm run build:backend && cross-env USE_FAST_SASS=true npm run build:frontend && npm run pseudolocalize && npm run copy",
     "build:prod": "npm run build:backend && npm run build:frontend && npm run copy",
     "build:backend": "tsc -p tsconfig.backend.json",
     "build:frontend": "react-scripts build",
@@ -29,8 +29,8 @@
     "electron:debug": "cross-env NODE_ENV=development electron lib/backend/main.js",
     "lint": "tslint -p . 1>&2",
     "pseudolocalize": "betools pseudolocalize --englishDir ./public/locales/en --out ./build/locales/en-PSEUDO",
-    "start": "npm run build:backend && run-p \"start:frontend\" \"electron:debug\"",
-    "start:frontend": "npm run pseudolocalize && cross-env USE_FAST_SASS=true BROWSER=none react-scripts start"
+    "start": "npm run build && run-p \"start:frontend\" \"electron:debug\"",
+    "start:frontend": "cross-env USE_FAST_SASS=true BROWSER=none react-scripts start"
   },
   "browserslist": [
     "electron 6.0.0",

--- a/src/frontend/components/AppComponent.tsx
+++ b/src/frontend/components/AppComponent.tsx
@@ -7,8 +7,9 @@ import * as path from "path";
 import { Provider } from "react-redux";
 import { Config, OpenMode } from "@bentley/bentleyjs-core";
 import { ContextRegistryClient, Project } from "@bentley/context-registry-client";
-import { IModelQuery } from "@bentley/imodelhub-client";
-import { AuthorizedFrontendRequestContext, FrontendRequestContext, IModelApp, IModelConnection, NotifyMessageDetails, OutputMessagePriority, OutputMessageType, RemoteBriefcaseConnection, SnapshotConnection, ViewState } from "@bentley/imodeljs-frontend";
+import { HubIModel, IModelQuery } from "@bentley/imodelhub-client";
+import { AuthorizedFrontendRequestContext, FrontendRequestContext, IModelApp, IModelConnection, MessageBoxIconType, MessageBoxType,
+  NotifyMessageDetails, OutputMessagePriority, OutputMessageType, RemoteBriefcaseConnection, SnapshotConnection, ViewState } from "@bentley/imodeljs-frontend";
 import { SignIn } from "@bentley/ui-components";
 import { ConfigurableUiContent, FrontstageManager, FrontstageProvider, MessageManager, SyncUiEventDispatcher, UiFramework } from "@bentley/ui-framework";
 import { UiItemsManager } from "@bentley/ui-abstract";
@@ -194,8 +195,8 @@ export default class AppComponent extends React.Component<{}, AppState> {
       "BisCore:OrthographicViewDefinition",
     ];
     const acceptedViewSpecs = viewSpecs.filter((spec) => (-1 !== acceptedViewClasses.indexOf(spec.classFullName)));
-    if (!acceptedViewSpecs) {
-      MessageManager.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, IModelApp.i18n.translate("App:noViewDefinition"), undefined, OutputMessageType.Alert));
+    if (!acceptedViewSpecs.length) {
+      await IModelApp.notifications.openMessageBox(MessageBoxType.Ok, IModelApp.i18n.translate("App:noViewDefinition", undefined), MessageBoxIconType.Information);
       return null;
     }
 
@@ -327,7 +328,8 @@ export default class AppComponent extends React.Component<{}, AppState> {
       // attempt to open the imodel
       imodel = await SnapshotConnection.openFile(this.snapshotName);
     } catch (e) {
-      MessageManager.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, IModelApp.i18n.translate("App:errorOpenSnapshot", {snapshotName: this.snapshotName, e}), undefined, OutputMessageType.Alert));
+      this.setState({ isOpening: false });
+      await IModelApp.notifications.openMessageBox(MessageBoxType.Ok, IModelApp.i18n.translate("App:errorOpenSnapshot", {snapshotName: this.snapshotName, e}), MessageBoxIconType.Critical);
       this.doReselectOnError();
       return;
     }
@@ -344,10 +346,13 @@ export default class AppComponent extends React.Component<{}, AppState> {
 
     const requestContext: AuthorizedFrontendRequestContext = await AuthorizedFrontendRequestContext.create();
     const connectClient = new ContextRegistryClient();
-    let project: Project;
+    let project: Project | undefined;
     try {
       project = await connectClient.getProject(requestContext, { $filter: `Name+eq+'${this.projectName}'` });
     } catch (e) {
+      project = undefined;
+    }
+    if (!project) {
       this.setState({ isOpening: false });
       MessageManager.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, IModelApp.i18n.translate("App:noProject", {projectName: this.projectName}), undefined, OutputMessageType.Alert));
       this.doReselectOnError();
@@ -356,8 +361,13 @@ export default class AppComponent extends React.Component<{}, AppState> {
 
     const imodelQuery = new IModelQuery();
     imodelQuery.byName(this.imodelName);
-    const imodels = await IModelApp.iModelClient.iModels.get(requestContext, project.wsgId, imodelQuery);
-    if (!imodels) {
+    let imodels: HubIModel[] | undefined;
+    try {
+      imodels = await IModelApp.iModelClient.iModels.get(requestContext, project.wsgId, imodelQuery);
+    } catch (e) {
+      imodels = undefined;
+    }
+    if (!imodels || !imodels.length) {
       this.setState({ isOpening: false });
       MessageManager.outputMessage(new NotifyMessageDetails(OutputMessagePriority.Error, IModelApp.i18n.translate("App:noIModel", {imodelName: this.imodelName, projectName: this.projectName}), undefined, OutputMessageType.Alert));
       this.doReselectOnError();


### PR DESCRIPTION
Also tweaked the build script to do the pseudolocalize after the build so that it would include the App.json file.  I was seeing console messages that the localization was not found for App.json strings.  I had to add the additional 'npm run build' step in the Development Setup of the README since I could not find a way to include this pseudolocalization within the 'npm run start' script.