### PR TITLE
Update workflow to run on all pull requests into master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
The current workflow does not get triggered when the PR is open.  The behavior of GH Actions is a bit different than ADOps Pipelines in this way.

Since GH Actions are always triggered by a specified [GH web hook](https://docs.github.com/en/actions/reference/events-that-trigger-workflows), the explicit "pull_request" hook needs to be added.  It's not enough to rely on the required status checks.