### PR TITLE
Update README to not include the "npm run build".  Remove explicit pseudo-localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ assets/*.Tiles*
 node_modules
 build
 lib
+
+.DS_Store
+*.tgz

--- a/README.md
+++ b/README.md
@@ -16,13 +16,7 @@ See <http://imodeljs.org> for comprehensive documentation on the iModel.js API a
     npm install
     ```
 
-2. Build the app:
-
-    ```sh
-    npm run build
-    ```
-
-3. Start the app:
+1. Start the app:
 
     ```sh
     npm start

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "npm run build:backend && cross-env USE_FAST_SASS=true npm run build:frontend && npm run pseudolocalize && npm run copy",
+    "build": "npm run build:backend && cross-env USE_FAST_SASS=true npm run build:frontend && npm run copy",
     "build:prod": "npm run build:backend && npm run build:frontend && npm run copy",
     "build:backend": "tsc -p tsconfig.backend.json",
     "build:frontend": "react-scripts build",
@@ -28,7 +28,6 @@
     "electron": "electron lib/backend/main.js",
     "electron:debug": "cross-env NODE_ENV=development electron lib/backend/main.js",
     "lint": "tslint -p . 1>&2",
-    "pseudolocalize": "betools pseudolocalize --englishDir ./public/locales/en --out ./build/locales/en-PSEUDO",
     "start": "npm run build && run-p \"start:frontend\" \"electron:debug\"",
     "start:frontend": "cross-env USE_FAST_SASS=true BROWSER=none react-scripts start"
   },


### PR DESCRIPTION
The `npm run start` script now includes the `npm run build` script so the duplicative step isn't needed.

Remove the pseudo-localization done by the app.  We can't currently turn off the default pseudo-localization done by imodeljs-i18n.  I'll look into making that possible as well.