### PR TITLE
Add on-demand CI trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
The current triggers for the CI build don't include the ability to manually queue it if needed.