### PR TITLE
Allow the getConfig ipc method to be called more than once

### DIFF
--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -83,7 +83,7 @@ const initialize = async () =>  {
   }
 
   // register handlers for viewer's IPC methods.
-  ipcMain.handleOnce(appIpc("getConfig"), async () => getFrontendConfig());
+  ipcMain.handle(appIpc("getConfig"), async () => getFrontendConfig());
   ipcMain.handle(appIpc("openFile"), async (_event: any, options: any) => dialog.showOpenDialog(options));
 }
 


### PR DESCRIPTION
Hot module reloading the frontend is currently broken due to an error stating the getConfig ipc method is no longer available.  This happens because the ipc method is set to `handleOnce` in main process.  Switching this to allow it to be called more than once and thus be called again when the frontend is reloaded.

@jffmarker turns out there was an issue keeping it this way. :)  It shouldn't impact the packaged version of the app, only the development workflow. 