### PR TITLE
Fix presentation rules in bundled app

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -2,15 +2,16 @@ appId: Bentley.DesktopStarter
 productName: Desktop Starter
 extends: react-cra
 files:
-- build/**/*
-- node_modules/**/*
-- "!**/*.map"
-- "!**/*.d.ts"
-- "!**/*.tsbuildinfo"
+  - build/**/*
+  - node_modules/**/*
+  - "!**/*.map"
+  - "!**/*.d.ts"
+  - "!**/*.tsbuildinfo"
 extraMetadata:
   main: build/app/main.js
 asarUnpack:
-- build/assets/**/*
+  - build/assets/**/*
+  - build/app/**/*
 mac:
   category: public.app-category.developer-tools
 win:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "version": "1.0.7",
   "private": true,
   "scripts": {
-    "build": "run-p build:backend build:frontend copy",
+    "build": "run-p build:backend build:frontend && npm run copy",
     "build:backend": "tsc -p tsconfig.backend.json && npm run build:backend:webpack",
     "watch:backend": "tsc -p tsconfig.backend.json --watch",
     "build:backend:webpack": "backend-webpack-tools build -s ./lib/backend/main.js -o ./build/app/",

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -10,6 +10,7 @@ import { Presentation } from "@bentley/presentation-backend";
 import { AppLoggerCategory } from "../common/LoggerCategory";
 import { desktopStarterChannel, DesktopStarterInterface, getRpcInterfaces, ViewerConfig } from "../common/ViewerProps";
 import { IpcHandler } from "@bentley/imodeljs-backend";
+import { PRESENTATION_COMMON_ASSETS_ROOT, PRESENTATION_BACKEND_ASSETS_ROOT  } from "@bentley/presentation-backend/lib/presentation-backend/Constants";
 
 const appInfo = {
   id: "app",
@@ -80,7 +81,16 @@ const initialize = async () => {
   await ElectronHost.startup(opts);
 
   // Initialize Presentation
-  Presentation.initialize();
+  Presentation.initialize({
+    presentationAssetsRoot: {
+      backend: ElectronHost.app.isPackaged
+        ? path.join(PRESENTATION_BACKEND_ASSETS_ROOT).replace("app.asar", "app.asar.unpacked")
+        : PRESENTATION_BACKEND_ASSETS_ROOT,
+      common: ElectronHost.app.isPackaged
+        ? path.join(PRESENTATION_COMMON_ASSETS_ROOT).replace("app.asar", "app.asar.unpacked")
+        : PRESENTATION_COMMON_ASSETS_ROOT,
+    },
+  });
 
   await ElectronHost.openMainWindow({ width: 1280, height: 800, show: true });
 

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -10,7 +10,7 @@ import { Presentation } from "@bentley/presentation-backend";
 import { AppLoggerCategory } from "../common/LoggerCategory";
 import { desktopStarterChannel, DesktopStarterInterface, getRpcInterfaces, ViewerConfig } from "../common/ViewerProps";
 import { IpcHandler } from "@bentley/imodeljs-backend";
-import { PRESENTATION_COMMON_ASSETS_ROOT, PRESENTATION_BACKEND_ASSETS_ROOT  } from "@bentley/presentation-backend/lib/presentation-backend/Constants";
+import { PRESENTATION_BACKEND_ASSETS_ROOT, PRESENTATION_COMMON_ASSETS_ROOT } from "@bentley/presentation-backend/lib/presentation-backend/Constants";
 
 const appInfo = {
   id: "app",


### PR DESCRIPTION
After debugging into issue #67, it became apparent that we are not able to properly resolve the presentation rule sets due to it being bundled within the "asar" created by electron builder. I updated the electron-builder.yaml to also unpack the app/assets in addition to the build/assets.

Switching this caused me to also change the directories used by the PresentationManager to use `app.asar.unpacked` in the path instead of `app.asar`.

@grigasp fyi, there is probably a better way to do this in a bundled app so we'll need to investigate it to see the best way to move forward.