### PR TITLE
Only replace first replace flag

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -21,7 +21,7 @@ jobs:
         name: git config
       - run: npm ci
       - run: npx run-s lint build build:backend:webpack
-      - run: ((Get-Content -path ./build/app/main.js -Raw) -replace 'REPLACE_WITH_CLIENT_ID', ${env:IMJS_ELECTRON_CLIENT_ID}) | Set-Content -Path ./build/app/main.js
+      - run: ([Regex]'REPLACE_WITH_CLIENT_ID').Replace((Get-Content -path ./build/app/main.js -Raw), ${env:IMJS_ELECTRON_CLIENT_ID}, 1) | Set-Content -Path ./build/app/main.js
         shell: powershell
         name: set client id
       - run: npm run build:dist


### PR DESCRIPTION
- The current release is not able to launch due to the `REPLACE_WITH_CLIENT_ID` check
- This PR changes the release pipeline to only replace the first instance of the "REPLACE_ME" string